### PR TITLE
Add workouts section skeleton

### DIFF
--- a/src/app/workouts/[id]/page.tsx
+++ b/src/app/workouts/[id]/page.tsx
@@ -1,0 +1,13 @@
+interface WorkoutDetailPageProps {
+  params: { id: string };
+}
+
+export default function WorkoutDetailPage({ params }: WorkoutDetailPageProps) {
+  const { id } = params;
+  return (
+    <div>
+      <h1>Workout Detail - {id}</h1>
+      {/* TODO: show workout detail here */}
+    </div>
+  );
+}

--- a/src/app/workouts/new/page.tsx
+++ b/src/app/workouts/new/page.tsx
@@ -1,0 +1,8 @@
+export default function NewWorkoutPage() {
+  return (
+    <div>
+      <h1>Add New Workout</h1>
+      {/* TODO: add workout form here */}
+    </div>
+  );
+}

--- a/src/app/workouts/page.tsx
+++ b/src/app/workouts/page.tsx
@@ -1,0 +1,8 @@
+export default function WorkoutsPage() {
+  return (
+    <div>
+      <h1>Workout Records</h1>
+      {/* TODO: list workouts here */}
+    </div>
+  );
+}

--- a/src/components/WorkoutForm.tsx
+++ b/src/components/WorkoutForm.tsx
@@ -1,0 +1,8 @@
+export default function WorkoutForm() {
+  return (
+    <form>
+      {/* TODO: workout form fields */}
+      <button type="submit">Save</button>
+    </form>
+  );
+}

--- a/src/components/WorkoutList.tsx
+++ b/src/components/WorkoutList.tsx
@@ -1,0 +1,13 @@
+interface WorkoutListProps {
+  workouts: { id: string; title: string }[];
+}
+
+export default function WorkoutList({ workouts }: WorkoutListProps) {
+  return (
+    <ul>
+      {workouts.map((workout) => (
+        <li key={workout.id}>{workout.title}</li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/workouts.ts
+++ b/src/lib/workouts.ts
@@ -1,0 +1,9 @@
+export interface Workout {
+  id: string;
+  title: string;
+}
+
+export async function fetchWorkouts(): Promise<Workout[]> {
+  // TODO: fetch workouts from API or database
+  return [];
+}


### PR DESCRIPTION
## Summary
- add pages for listing workouts, creating new workouts, and viewing workout details
- scaffold WorkoutForm and WorkoutList components
- add simple workouts library stub

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cdce7464832fbb42754fe06d9cf5